### PR TITLE
Add now.json config for deploying to ZEIT

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [{
+    "src": "package.json",
+    "use": "@now/static-build",
+    "config": { "distDir": "out" }
+  }],
+  "build": {
+    "env": {
+      "BUTTER_CMS_API_KEY": "@butter-cms-api-key"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "next",
     "build": "next build",
     "export": "yarn build && next export",
-    "cypress:open": "cypress open"
+    "cypress:open": "cypress open",
+    "now-build": "yarn export"
   },
   "dependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",


### PR DESCRIPTION
This adds config for deploying to zeit.co.

Once you have an account at zeit.co, download [the CLI](https://zeit.co/download) and configure your API key as a secret.

`now secrets add butter-cms-api-key "YOUR_API_KEY"`

Finally, run `now` at the project root.