### PR TITLE
Add steps for deploying to ZEIT to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@ This app demonstrates how you can test a Next.js app using Cypress.
 
 <img src="https://user-images.githubusercontent.com/6391763/54627869-47b56500-4a9a-11e9-812e-ddb71b56f56e.png" alt="Preview">
 
-<!-- prettier-ignore-start -->
-
-![Netlify Status][netlify-badge]
-
-<!-- prettier-ignore-end -->
-
 ## Demo
 
-Please check out the Netlify demo at https://buttercms-marketing-site-nextjs-react.netlify.com/.
+Please check out the ZEIT demo at https://testing-nextjs-apps.ghoshnirmalya.now.sh/.
 
 ## Development
 
@@ -58,18 +52,18 @@ If you prefer `npm`, you can do `npm run cypress open` instead of `yarn run cypr
 
 ## Built With
 
-* [Blue](https://cruip.com/blue/) - Landing page template from [Cruip](https://cruip.com/).
-* [Next.js](https://nextjs.org/) - The React.js framework for building SSR web apps.
-* [React](https://facebook.github.io/react/) - A JavaScript library for building user interfaces
-* [Screely](https://www.screely.com/) - Instantly turn your screenshot into a beautiful design mockup
-* [Cypress](https://www.cypress.io/) - Fast, easy and reliable testing for anything that runs in a browser.
+- [Blue](https://cruip.com/blue/) - Landing page template from [Cruip](https://cruip.com/).
+- [Next.js](https://nextjs.org/) - The React.js framework for building SSR web apps.
+- [React](https://facebook.github.io/react/) - A JavaScript library for building user interfaces
+- [Screely](https://www.screely.com/) - Instantly turn your screenshot into a beautiful design mockup
+- [Cypress](https://www.cypress.io/) - Fast, easy and reliable testing for anything that runs in a browser.
+
+## Deploying
+
+1. Create a ZEIT account at https://zeit.co/signup and download [the CLI](https://zeit.co/download)
+2. Add the API key as a secret `now secrets add butter-cms-api-key "YOUR_API_KEY"`
+3. Run `now` at the project root
 
 ## License
 
 MIT Licensed. Copyright (c) ButterCMS 2019.
-
-<!-- prettier-ignore-start -->
-
-[netlify-badge]: https://api.netlify.com/api/v1/badges/6d6612a8-c4f4-44d6-a5d7-81e6afec737b/deploy-status
-
-<!-- prettier-ignore-end -->

--- a/package.json
+++ b/package.json
@@ -31,10 +31,14 @@
     }
   },
   "lint-staged": {
-    "*.{js,json,css,md}": ["prettier --write", "git add"]
+    "*.{js,json,css,md}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "devDependencies": {
     "husky": "^1.3.1",
-    "lint-staged": "^8.1.3"
+    "lint-staged": "^8.1.3",
+    "prettier": "^1.18.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4648,6 +4648,11 @@ postcss@^7.0.0:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-time@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"


### PR DESCRIPTION
Adds some notes for deploying in case a user wants to try it out. Also, noticed that `prettier` was missing from `devDependencies` so added that in.